### PR TITLE
Removendo terraform-wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.0.0
-          terraform_wrapper: false
 
       - name: Terraform Format
         id: fmt


### PR DESCRIPTION
# Removendo terraform-wrapper

PR para resolver a issue #7  e retirar o módulo `terraform-wrapper = false`

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

Close #7 

## Objetivo

Remover linha com terraform-wrapper, pois estava com o value `False` e afetando os outputs dos demais blocos, por padrão ele deve ativo. 

## Referências

https://github.com/marketplace/actions/hashicorp-setup-terraform